### PR TITLE
Fix downloading single assets

### DIFF
--- a/controllers/single_page/assets/download.php
+++ b/controllers/single_page/assets/download.php
@@ -300,7 +300,7 @@ class Download extends PageController
 
         foreach ($files as $file) {
             $assetFile = $file->getAssetFile();
-            $zip->addFile($assetFile->getRelativePath(), $assetFile->getFileName());
+            $zip->addFile(DIR_BASE . $assetFile->getRelativePath(), $assetFile->getFileName());
         }
 
         // If we actually have files in the zip


### PR DESCRIPTION
I can't explain why this is needed because it's the same as the collection and lightbox controllers, but for some reason, just using getRelativePath() causes the file not to be added to $zip resulting in $zip->numFiles = 0